### PR TITLE
Claude Code sandbox トグルショートカット (Cmd+Ctrl+S) を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
         "command": "secondaryTerminal.pasteImage",
         "title": "Paste Image from Clipboard",
         "category": "Secondary Terminal"
+      },
+      {
+        "command": "secondaryTerminal.toggleClaudeSandbox",
+        "title": "Toggle Claude Sandbox",
+        "category": "Secondary Terminal"
       }
     ],
     "menus": {
@@ -135,6 +140,10 @@
         "command": "secondaryTerminal.copyMainTerminalSelection",
         "key": "cmd+shift+l",
         "when": "terminalFocus"
+      },
+      {
+        "command": "secondaryTerminal.toggleClaudeSandbox",
+        "key": "cmd+ctrl+s"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
       },
       {
         "command": "secondaryTerminal.toggleClaudeSandbox",
-        "key": "cmd+ctrl+s"
+        "key": "cmd+ctrl+s",
+        "when": "workspaceFolderCount > 0"
       }
     ],
     "configuration": {

--- a/src/claudeSandboxToggle.ts
+++ b/src/claudeSandboxToggle.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SETTINGS_FILENAME = 'settings.local.json';
+const CLAUDE_DIR = '.claude';
+
+export interface ToggleResult {
+    enabled: boolean;
+}
+
+export function toggleClaudeSandbox(workspaceRoot: string): ToggleResult {
+    const claudeDir = path.join(workspaceRoot, CLAUDE_DIR);
+    const settingsPath = path.join(claudeDir, SETTINGS_FILENAME);
+
+    if (!fs.existsSync(claudeDir)) {
+        fs.mkdirSync(claudeDir, { recursive: true });
+    }
+
+    let json: Record<string, any> = {};
+    if (fs.existsSync(settingsPath)) {
+        const content = fs.readFileSync(settingsPath, 'utf8');
+        const parsed = JSON.parse(content);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            throw new Error(`${settingsPath} is not a JSON object`);
+        }
+        json = parsed;
+    }
+
+    const current = json.sandbox?.enabled === true;
+    const next = !current;
+
+    if (!json.sandbox || typeof json.sandbox !== 'object' || Array.isArray(json.sandbox)) {
+        json.sandbox = {};
+    }
+    json.sandbox.enabled = next;
+
+    fs.writeFileSync(settingsPath, JSON.stringify(json, null, 2) + '\n');
+
+    return { enabled: next };
+}

--- a/src/claudeSandboxToggle.ts
+++ b/src/claudeSandboxToggle.ts
@@ -18,12 +18,14 @@ export function toggleClaudeSandbox(workspaceRoot: string): ToggleResult {
 
     let json: Record<string, any> = {};
     if (fs.existsSync(settingsPath)) {
-        const content = fs.readFileSync(settingsPath, 'utf8');
-        const parsed = JSON.parse(content);
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-            throw new Error(`${settingsPath} is not a JSON object`);
+        const content = fs.readFileSync(settingsPath, 'utf8').trim();
+        if (content !== '') {
+            const parsed = JSON.parse(content);
+            if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+                throw new Error(`${settingsPath} is not a JSON object`);
+            }
+            json = parsed;
         }
-        json = parsed;
     }
 
     const current = json.sandbox?.enabled === true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { TerminalSessionManager } from './terminalSessionManager';
 import { createContextTextForSelectedText } from './utils';
 import { registerDropZoneProvider } from './dropZoneProvider';
 import { getImageFromClipboard } from './clipboardImageHandler';
+import { toggleClaudeSandbox } from './claudeSandboxToggle';
 
 /**
  * ターミナルの選択テキストをクリップボードにコピーして取得
@@ -208,6 +209,25 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.setStatusBarMessage('$(check) Image pasted', 3000);
             } else {
                 vscode.window.showInformationMessage('No image found in clipboard');
+            }
+        })
+    );
+
+    // Claude Code の sandbox をトグル (<workspace>/.claude/settings.local.json の sandbox.enabled)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('secondaryTerminal.toggleClaudeSandbox', () => {
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            if (!workspaceFolder) {
+                vscode.window.showWarningMessage('No workspace folder open');
+                return;
+            }
+            try {
+                const result = toggleClaudeSandbox(workspaceFolder.uri.fsPath);
+                const status = result.enabled ? 'ON' : 'OFF';
+                vscode.window.showInformationMessage(`Claude sandbox: ${status}`);
+            } catch (error) {
+                const msg = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to toggle Claude sandbox: ${msg}`);
             }
         })
     );


### PR DESCRIPTION
## Summary
- Secondary Terminal 拡張に `secondaryTerminal.toggleClaudeSandbox` コマンドを追加
- `Cmd+Ctrl+S` でワークスペース直下の `.claude/settings.local.json` の `sandbox.enabled` をトグル
- 実行結果は VSCode トーストで `Claude sandbox: ON` / `OFF` と通知
- `.claude/` ディレクトリや `settings.local.json` が無い場合は自動作成

## 背景
Claude Code の sandbox モードは `.claude/settings.local.json` の `sandbox.enabled` (boolean) で制御される。既存の Rust CLI (`~/home-files/rust/claude-code-sandbox-status`) を使わなくても VSCode 内で完結させたかった。

Rust 実装との差分:
- ワークスペースルートは VSCode API から取得できるため、CWD からの walk-up 探索を省略
- `~/.claude/settings.json` へのフォールバックも省略

## Test plan
- [ ] `npm run compile` が通ること
- [ ] F5 で Extension Development Host を起動し、`.claude/` 有りのワークスペースで `Cmd+Ctrl+S` → トースト `Claude sandbox: ON`
- [ ] `.claude/settings.local.json` の `sandbox.enabled` が反転することを確認
- [ ] もう一度 `Cmd+Ctrl+S` で逆の値に戻ること
- [ ] `.claude/` 無しのワークスペースでも `.claude/settings.local.json` が新規作成され、トーストが出ること
- [ ] ワークスペース未オープン時は warning トーストが出ること